### PR TITLE
Style changes in admin_dashboard.css

### DIFF
--- a/src/front/styles/admin_dashboard.css
+++ b/src/front/styles/admin_dashboard.css
@@ -1,19 +1,18 @@
 .bg-pinki {
-  background-color: #faedcd;
+  background-color: var(--color-background-tag);
 }
 
 .bg-verde {
-  background-color: #ccd5ae;
+  background-color: var(--color-background-pill);
 }
 
 .title-recipes {
-  background-color: #ccd5ae;
+  background-color: var(--color-background-pill);
 }
 
-
 .card-link {
-  text-decoration: none; 
-  color: inherit; 
+  text-decoration: none;
+  color: inherit;
 }
 
 .card-hover-effect {
@@ -21,10 +20,20 @@
   cursor: pointer;
 }
 
-
-.card-efect:hover {
-  transform: translateY(-5px); 
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2),
-              0 0 15px 5px #ccd5ae; 
+.dark-mode .bg-pinki {
+  background-color: var(--color-background-tag);
 }
 
+.dark-mode .bg-verde {
+  background-color: var(--color-background-pill);
+}
+
+.dark-mode .title-recipes {
+  background-color: var(--color-background-pill);
+  color: var(--color-text-main);
+}
+
+.card-efect:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2), 0 0 15px 5px #ccd5ae;
+}


### PR DESCRIPTION
The fixed background colors, such as #faedcd (a light/pink color) and #ccd5ae (a light green/gray color), were replaced by the dynamic variables you have defined in index.css: background-color: #faedcd; $\rightarrow$ background-color: var(--color-background-tag); background-color: #ccd5ae; $\rightarrow$ background-color: var(--color-background-pill);
The `.dark-mode` selectors were added to these same elements (`.bg-pinki`, `.bg-verde`, `.title-recipes`).
Within these selectors, the dark mode variable is applied to the background, and the text color (`--color-text-main`) is adjusted to ensure readability on dark backgrounds.