### PR TITLE
Modifications for dark mode in recipe_list and recipeDetail

### DIFF
--- a/src/front/styles/recipeDetail.css
+++ b/src/front/styles/recipeDetail.css
@@ -1,315 +1,370 @@
 .recipe-detail-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 40px 20px;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 40px 20px;
 }
 
 .error-container {
-  text-align: center;
-  padding: 80px 20px;
+    text-align: center;
+    padding: 80px 20px;
 }
 
 .error-container h2 {
-  color: var(--color-dark);
-  margin-bottom: 20px;
+    color: var(--color-text-title);
+    margin-bottom: 20px;
+    transition: color 0.4s ease;
 }
 
 /* ===== BACK BUTTON ===== */
 .back-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--color-tan);
-  text-decoration: none;
-  font-weight: 600;
-  margin-bottom: 30px;
-  padding: 10px 20px;
-  border-radius: 8px;
-  transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-text-highlight);
+    text-decoration: none;
+    font-weight: 600;
+    margin-bottom: 30px;
+    padding: 10px 20px;
+    border-radius: 8px;
+    transition: all 0.3s ease;
 }
 
 .back-button:hover {
-  background: var(--color-cream);
-  transform: translateX(-5px);
+    background: var(--color-background-tag);
+    transform: translateX(-5px);
 }
 
-/* ===== HERO SECTION ===== */
+.dark-mode .back-button:hover {
+    background: var(--color-background-pill);
+}
+
+/* ===== HERO SECTION (Fondo degradado) ===== */
 .recipe-hero {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 50px;
-  align-items: start;
-  margin-bottom: 60px;
-  padding: 40px;
-  background: linear-gradient(135deg, var(--color-cream) 0%, var(--color-peach) 100%);
-  border-radius: 24px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 50px;
+    align-items: start;
+    margin-bottom: 60px;
+    padding: 40px;
+    /* Usamos el degradado del botón primario */
+    background: linear-gradient(135deg, var(--color-btn-secondary) 0%, var(--color-background-tag) 100%);
+    border-radius: 24px;
+    transition: background 0.4s ease;
+}
+
+/* Ajuste del degradado en modo oscuro */
+.dark-mode .recipe-hero {
+    background: linear-gradient(135deg, var(--color-background-card) 0%, var(--color-background-section) 100%);
 }
 
 .recipe-detail-title {
-  font-size: 2.8rem;
-  font-weight: 800;
-  color: var(--color-dark);
-  margin-bottom: 24px;
-  line-height: 1.2;
+    font-size: 2.8rem;
+    font-weight: 800;
+    color: var(--color-text-title);
+    margin-bottom: 24px;
+    line-height: 1.2;
+    transition: color 0.4s ease;
 }
 
 .recipe-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 20px;
 }
 
 .badge-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 18px;
-  background: white;
-  border-radius: 20px;
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--color-dark);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  text-transform: capitalize;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 18px;
+    /* Fondo de badge ajustado a la variable */
+    background: var(--color-background-main);
+    border-radius: 20px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--color-text-main);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    text-transform: capitalize;
+    transition: all 0.4s ease;
 }
 
+.dark-mode .badge-item {
+    background: var(--color-background-pill);
+    box-shadow: none;
+}
+
+
 .badge-item.difficulty {
-  background: var(--color-tan);
-  color: white;
+    /* Color de acento principal */
+    background: var(--color-text-highlight);
+    color: white;
 }
 
 .badge-item.category {
-  background: var(--color-sage);
+    /* Color de botón secundario/píldora */
+    background: var(--color-background-pill);
+    color: var(--color-text-title);
 }
 
 .badge-item i {
-  font-size: 1.1rem;
+    font-size: 1.1rem;
 }
 
 .recipe-detail-rating {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-top: 20px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 20px;
 }
 
 .stars {
-  display: flex;
-  gap: 4px;
+    display: flex;
+    gap: 4px;
 }
 
 .stars i {
-  color: #ffc107;
-  font-size: 1.3rem;
+    /* Color de estrella ajustado a Highlight */
+    color: var(--color-text-highlight);
+    font-size: 1.3rem;
 }
 
 .rating-text {
-  font-weight: 600;
-  color: #666;
+    font-weight: 600;
+    /* Color de texto meta/secundario */
+    color: var(--color-text-meta);
+    transition: color 0.4s ease;
 }
 
 .recipe-hero-image {
-  border-radius: 20px;
-  overflow: hidden;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
-  height: 450px;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+    height: 450px;
+}
+
+/* Ajuste de sombra en modo oscuro */
+.dark-mode .recipe-hero-image {
+    box-shadow: 0 20px 60px rgba(255, 255, 255, 0.1);
 }
 
 .recipe-hero-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 /* ===== MAIN CONTENT ===== */
 .recipe-content {
-  display: grid;
-  grid-template-columns: 1fr 1.5fr;
-  gap: 50px;
-  margin-bottom: 50px;
+    display: grid;
+    grid-template-columns: 1fr 1.5fr;
+    gap: 50px;
+    margin-bottom: 50px;
 }
 
 .section-title {
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: var(--color-dark);
-  margin-bottom: 24px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--color-text-title);
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    transition: color 0.4s ease;
 }
 
 .section-title i {
-  color: var(--color-tan);
+    color: var(--color-text-highlight);
 }
 
 /* ===== INGREDIENTS ===== */
 .ingredients-section {
-  background: white;
-  padding: 30px;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  height: fit-content;
-  position: sticky;
-  top: 20px;
+    /* Fondo de la sección/tarjeta */
+    background: var(--color-background-section);
+    padding: 30px;
+    border-radius: 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    height: fit-content;
+    position: sticky;
+    top: 20px;
+    transition: background 0.4s ease, box-shadow 0.4s ease;
+}
+
+.dark-mode .ingredients-section {
+    box-shadow: 0 4px 20px rgba(255, 255, 255, 0.05);
 }
 
 .ingredients-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .ingredient-item {
-  display: grid;
-  grid-template-columns: 20px 1fr auto;
-  gap: 12px;
-  align-items: center;
-  padding: 12px;
-  background: var(--color-cream);
-  border-radius: 8px;
-  transition: all 0.2s ease;
+    display: grid;
+    grid-template-columns: 20px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    padding: 12px;
+    /* Fondo del ítem de la lista */
+    background: var(--color-background-tag);
+    border-radius: 8px;
+    transition: all 0.2s ease;
 }
 
 .ingredient-item:hover {
-  background: var(--color-light-sage);
-  transform: translateX(5px);
+    background: var(--color-background-pill);
+    transform: translateX(5px);
 }
 
 .ingredient-bullet {
-  color: var(--color-tan);
-  font-size: 1.5rem;
-  font-weight: bold;
+    color: var(--color-text-highlight);
+    font-size: 1.5rem;
+    font-weight: bold;
 }
 
 .ingredient-name {
-  font-weight: 600;
-  color: var(--color-dark);
-  text-transform: capitalize;
+    font-weight: 600;
+    color: var(--color-text-main);
+    text-transform: capitalize;
 }
 
 .ingredient-quantity {
-  font-weight: 600;
-  color: var(--color-tan);
-  white-space: nowrap;
+    font-weight: 600;
+    color: var(--color-text-highlight);
+    white-space: nowrap;
 }
 
 /* ===== STEPS ===== */
 .steps-section {
-  background: white;
-  padding: 30px;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    /* Fondo de la sección/tarjeta */
+    background: var(--color-background-section);
+    padding: 30px;
+    border-radius: 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    transition: background 0.4s ease, box-shadow 0.4s ease;
+}
+
+.dark-mode .steps-section {
+    box-shadow: 0 4px 20px rgba(255, 255, 255, 0.05);
 }
 
 .steps-content {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
 }
 
 .step-item {
-  display: flex;
-  gap: 20px;
-  align-items: start;
+    display: flex;
+    gap: 20px;
+    align-items: start;
 }
 
 .step-number {
-  flex-shrink: 0;
-  width: 40px;
-  height: 40px;
-  background: var(--color-tan);
-  color: white;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: 1.1rem;
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    /* Fondo del número de paso */
+    background: var(--color-text-highlight);
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 1.1rem;
 }
 
 .step-text {
-  flex: 1;
-  line-height: 1.7;
-  color: var(--color-text);
-  margin: 0;
-  padding-top: 8px;
+    flex: 1;
+    line-height: 1.7;
+    /* Color de texto principal */
+    color: var(--color-text-main);
+    margin: 0;
+    padding-top: 8px;
 }
 
 /* ===== NUTRITIONAL SECTION ===== */
 .nutritional-section {
-  background: white;
-  padding: 30px;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    /* Fondo de la sección/tarjeta */
+    background: var(--color-background-section);
+    padding: 30px;
+    border-radius: 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    transition: background 0.4s ease, box-shadow 0.4s ease;
+}
+
+.dark-mode .nutritional-section {
+    box-shadow: 0 4px 20px rgba(255, 255, 255, 0.05);
 }
 
 .nutritional-content p {
-  line-height: 1.8;
-  color: var(--color-text);
+    line-height: 1.8;
+    color: var(--color-text-main);
+    transition: color 0.4s ease;
 }
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 992px) {
-  .recipe-hero {
-    grid-template-columns: 1fr;
-    gap: 30px;
-  }
-  
-  .recipe-hero-image {
-    height: 350px;
-  }
-  
-  .recipe-content {
-    grid-template-columns: 1fr;
-  }
-  
-  .ingredients-section {
-    position: relative;
-    top: 0;
-  }
+    .recipe-hero {
+        grid-template-columns: 1fr;
+        gap: 30px;
+    }
+    
+    .recipe-hero-image {
+        height: 350px;
+    }
+    
+    .recipe-content {
+        grid-template-columns: 1fr;
+    }
+    
+    .ingredients-section {
+        position: relative;
+        top: 0;
+    }
 }
 
 @media (max-width: 768px) {
-  .recipe-detail-title {
-    font-size: 2rem;
-  }
-  
-  .recipe-hero {
-    padding: 30px 20px;
-  }
-  
-  .section-title {
-    font-size: 1.5rem;
-  }
+    .recipe-detail-title {
+        font-size: 2rem;
+    }
+    
+    .recipe-hero {
+        padding: 30px 20px;
+    }
+    
+    .section-title {
+        font-size: 1.5rem;
+    }
 }
 
 @media (max-width: 576px) {
-  .recipe-detail-container {
-    padding: 20px 15px;
-  }
-  
-  .recipe-detail-title {
-    font-size: 1.6rem;
-  }
-  
-  .recipe-badges {
-    gap: 8px;
-  }
-  
-  .badge-item {
-    font-size: 0.85rem;
-    padding: 8px 14px;
-  }
-  
-  .ingredient-item {
-    grid-template-columns: 15px 1fr auto;
-    padding: 10px;
-  }
-  
-  .step-number {
-    width: 35px;
-    height: 35px;
-  }
+    .recipe-detail-container {
+        padding: 20px 15px;
+    }
+    
+    .recipe-detail-title {
+        font-size: 1.6rem;
+    }
+    
+    .recipe-badges {
+        gap: 8px;
+    }
+    
+    .badge-item {
+        font-size: 0.85rem;
+        padding: 8px 14px;
+    }
+    
+    .ingredient-item {
+        grid-template-columns: 15px 1fr auto;
+        padding: 10px;
+    }
+    
+    .step-number {
+        width: 35px;
+        height: 35px;
+    }
 }

--- a/src/front/styles/recipe_list.css
+++ b/src/front/styles/recipe_list.css
@@ -1,23 +1,45 @@
 .format-image {
-  width: 100%;
-  height: 200px;
-  object-fit: "cover";
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
 }
 
 .bg-pink {
-  background-color: #e9edc9;
+    /* Reemplazado #e9edc9 por la variable de fondo de tarjeta */
+    background-color: var(--color-background-card);
+    transition: background-color 0.4s ease;
 }
 
 .published {
-  background-color: #fefae0;
+    /* Reemplazado #fefae0 por la variable de fondo de sección */
+    background-color: var(--color-background-section);
+    transition: background-color 0.4s ease;
 }
 
 .title-rl {
-  background-color: #E9EDC9;
+    /* Reemplazado #e9edc9 por la variable de fondo de tarjeta/título */
+    background-color: var(--color-background-card);
+    transition: background-color 0.4s ease;
 }
 
 .image-container-fixed {
-  height: 200px;
-  overflow: hidden;
+    height: 200px;
+    overflow: hidden;
 }
 
+/* --- ESTILOS DE MODO OSCURO--- */
+
+.dark-mode .bg-pink {
+    background-color: var(--color-background-card);
+    color: var(--color-text-main);
+}
+
+.dark-mode .published {
+    background-color: var(--color-background-section);
+    color: var(--color-text-title);
+}
+
+.dark-mode .title-rl {
+    background-color: var(--color-background-card);
+    color: var(--color-text-title);
+}


### PR DESCRIPTION
This commit ensures visual consistency for the Dark/Light Mode feature across two complex views:

home.css: All hardcoded colors were replaced with dynamic CSS variables. Crucially, the decorative circles (.decoration-circle) were targeted with highly specific selectors (html.dark-mode .home-modern-container .circle-X) to successfully override conflicting styles and ensure they visibly change color and opacity over dark backgrounds.

categoryView.css: Fixed local color variables (e.g., --color-dark) were entirely removed and replaced by the global variables from index.css. This unified the styling logic for all structural elements, recipe cards, badges, and navigation links within the category view, ensuring full color responsiveness.

Result: Both pages now correctly adopt the global theme variables, resolving the "white layer" issue and integrating the Dark Mode aesthetic successfully.